### PR TITLE
fix generation; use cryptographic RNG

### DIFF
--- a/proquint.go
+++ b/proquint.go
@@ -4,17 +4,17 @@ package proquint
 
 import (
 	"fmt"
-	"math"
-	"math/rand"
+	"math/big"
+	"crypto/rand"
 	"strings"
 )
 
 var (
-	consonants = []string{"b", "d", "f", "g", "h", "j", "k", "l", "m", "n", "p", "s", "t", "v", "w", "z"}
-	vowels     = []string{"a", "e", "i", "o", "u", "r"}
+	consonants = []string{"b", "d", "f", "g", "h", "j", "k", "l", "m", "n", "p", "r", "s", "t", "v", "z"}
+	vowels     = []string{"a", "i", "o", "u"}
 )
 
-// Generate creates a proquint of of the length of words, separated by a dash.
+// Generate creates a proquint of the length of words, separated by a dash.
 //
 // https://merveilles.town/@flbr/115574222078642407
 func Generate(words int) (string, error) {
@@ -23,9 +23,13 @@ func Generate(words int) (string, error) {
 	}
 
 	var ret []string
-
+	max := big.NewInt(2 << 15)
 	for i := 0; i < words; i++ {
-		n := rand.Intn(int(math.Pow(2, 16)))
+		bigN, err := rand.Int(rand.Reader, max)
+		n := bigN.Int64()
+		if err != nil {
+			return "", err
+		}
 		word := fmt.Sprintf("%s%s%s%s%s", consonants[n>>12], vowels[(n>>10)&3], consonants[(n>>6)&15], vowels[(n>>4)&3], consonants[n&15])
 		ret = append(ret, word)
 	}


### PR DESCRIPTION
before this patch, the consonants and vowels lists weren't matching the proquint spec.

namely, 'v' and 'w' are interchangeable sounds (making generated IDs less useful); 'w' was removed per the spec. 'r' is not a vowel, it has been reinserted to the consonants list. 'e' has been removed from vowels for similar reasons as the removal of 'w' from the consonants list.

more importantly, since this was purported to be used for generating UUIDs, the source math/rand is less suitable as a source of randomness than crypto/rand, introduced in this patch.